### PR TITLE
Tweak Node options to reduce memory consumption during build

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,6 +10,8 @@ nodejs_version=20
 # Fail2ban
 failregex="immich-server.*Failed login attempt for user.+from ip address\s?<ADDR>"
 
+export NODE_OPTIONS=--max_old_space_size=3072
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================
@@ -153,16 +155,16 @@ myynh_install_immich() {
 	# Install immich-server
 		cd "$source_dir/server"
 		ynh_exec_warn_less "$ynh_npm" ci
-		ynh_exec_warn_less "$ynh_npm" run build
-		ynh_exec_warn_less "$ynh_npm" prune --omit=dev --omit=optional
+		ynh_exec_warn_less env "$ynh_npm" run build
+		ynh_exec_warn_less env "$ynh_npm" prune --omit=dev --omit=optional
 
 		cd "$source_dir/open-api/typescript-sdk"
-		ynh_exec_warn_less "$ynh_npm" ci
-		ynh_exec_warn_less "$ynh_npm" run build
+		ynh_exec_warn_less env "$ynh_npm" ci
+		ynh_exec_warn_less env "$ynh_npm" run build
 
 		cd "$source_dir/web"
-		ynh_exec_warn_less "$ynh_npm" ci
-		ynh_exec_warn_less "$ynh_npm" run build
+		ynh_exec_warn_less env "$ynh_npm" ci
+		ynh_exec_warn_less env "$ynh_npm" run build
 
 		mkdir -p "$install_dir/app/"
 		cp -a "$source_dir/server/node_modules" "$install_dir/app/"
@@ -216,7 +218,7 @@ myynh_install_immich() {
 
 	# Install sharp
 		cd "$install_dir/app"
-		ynh_exec_warn_less "$ynh_npm" install sharp
+		ynh_exec_warn_less env "$ynh_npm" install sharp
 
 	# Cleanup
 		ynh_secure_remove --file="$source_dir"


### PR DESCRIPTION
## Problem

Immich could not be built anymore on my server, despite having 2GB RAM and 5 GB swap.

## Solution

Use `NODE_OPTIONS=--max_old_space_size=3072` to enforce memory limits during build.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
