### PR TITLE
Fix required RAM extraction logic

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -55,7 +55,7 @@ myynh_add_swap() {
 	# Retrieve RAM needed in G
 		local ram_needed_full=$(ynh_read_manifest "integration.ram.build")
 		local ram_needed_value=${ram_needed_full::-1}
-		local ram_needed_unit=${ram_needed_full:1}
+		local ram_needed_unit=${ram_needed_full: -1}
 		if [ $ram_needed_unit = "M" ]
 		then
 			ram_needed_G=$(($ram_needed_value/1024))


### PR DESCRIPTION
## Problem

RAM extraction logic only works when RAM is specified in G. It is incorrect when the RAM is specified in M.

When RAM is specified in M, e.g. 512M then `local ram_needed_unit = 12M` (starting at index 1). As a result in the if condition the else branch for G is being entered which is not intended. Instead of calculating with 512M the script calculates with 512G then.

I came across this because I used this function in another app.

## Solution

Correct RAM retrieval logic by replacing `local ram_needed_unit=${ram_needed_full:1}` with `local ram_needed_unit=${ram_needed_full: -1}`. This just extracts the last char and thus fixes the logic. 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
